### PR TITLE
Add GitHub CLI to Omachy install and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Omachy brings the [Omarchy](https://omakub.org/) experience to macOS — a tilin
 | [Starship](https://starship.rs/) | Formula | Cross-shell prompt |
 | [fzf](https://github.com/junegunn/fzf) | Formula | Fuzzy finder |
 | [Lazygit](https://github.com/jesseduffield/lazygit) | Formula | Git TUI |
+| [GitHub CLI](https://cli.github.com/) | Formula | `gh` command-line client |
 | [opencode](https://github.com/sst/opencode) | Formula | AI coding agent CLI |
 | [Lazydocker](https://github.com/jesseduffield/lazydocker) | Formula | Docker TUI |
 | [Atuin](https://atuin.sh/) | Formula | Shell history search & sync |

--- a/docs/index.html
+++ b/docs/index.html
@@ -323,7 +323,7 @@
         </div>
         <div class="feature">
           <h3>What happens when I run it?</h3>
-          <p>The installer checks your system, backs up existing configs, installs ~15 tools via Homebrew, deploys pre-tuned configurations, and adjusts macOS system settings. Takes about 10 minutes. Fully reversible with <code style="background: var(--bg); padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.75rem;">omachy uninstall</code>.</p>
+          <p>The installer checks your system, backs up existing configs, installs 20+ tools via Homebrew, deploys pre-tuned configurations, and adjusts macOS system settings. Takes about 10 minutes. Fully reversible with <code style="background: var(--bg); padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.75rem;">omachy uninstall</code>.</p>
         </div>
       </div>
     </section>
@@ -367,9 +367,37 @@
           <div class="tool-name">Lazygit</div>
           <div class="tool-desc">Git TUI</div>
         </a>
+        <a class="tool" href="https://cli.github.com/" target="_blank" rel="noopener">
+          <div class="tool-name">GitHub CLI</div>
+          <div class="tool-desc">gh command-line client</div>
+        </a>
+        <a class="tool" href="https://github.com/sst/opencode" target="_blank" rel="noopener">
+          <div class="tool-name">opencode</div>
+          <div class="tool-desc">AI coding agent CLI</div>
+        </a>
+        <a class="tool" href="https://github.com/jesseduffield/lazydocker" target="_blank" rel="noopener">
+          <div class="tool-name">Lazydocker</div>
+          <div class="tool-desc">Docker TUI</div>
+        </a>
         <a class="tool" href="https://atuin.sh/" target="_blank" rel="noopener">
           <div class="tool-name">Atuin</div>
           <div class="tool-desc">Shell history search</div>
+        </a>
+        <a class="tool" href="https://github.com/fastfetch-cli/fastfetch" target="_blank" rel="noopener">
+          <div class="tool-name">fastfetch</div>
+          <div class="tool-desc">System info display</div>
+        </a>
+        <a class="tool" href="https://tree-sitter.github.io/tree-sitter/" target="_blank" rel="noopener">
+          <div class="tool-name">tree-sitter</div>
+          <div class="tool-desc">Parser generator</div>
+        </a>
+        <a class="tool" href="https://github.com/zsh-users/zsh-syntax-highlighting" target="_blank" rel="noopener">
+          <div class="tool-name">zsh-syntax-highlighting</div>
+          <div class="tool-desc">Fish-like syntax highlighting</div>
+        </a>
+        <a class="tool" href="https://github.com/zsh-users/zsh-autosuggestions" target="_blank" rel="noopener">
+          <div class="tool-name">zsh-autosuggestions</div>
+          <div class="tool-desc">Inline history suggestions</div>
         </a>
         <a class="tool" href="https://www.nerdfonts.com/" target="_blank" rel="noopener">
           <div class="tool-name">Nerd Fonts</div>

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -46,6 +46,7 @@ func Packages() []Package {
 		{Name: "starship"},
 		{Name: "fzf"},
 		{Name: "lazygit"},
+		{Name: "gh"},
 		{Name: "opencode"},
 		{Name: "lazydocker"},
 		{Name: "atuin"},

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestPackages(t *testing.T) {
 	pkgs := Packages()
-	if len(pkgs) != 21 {
-		t.Fatalf("expected 21 packages, got %d", len(pkgs))
+	if len(pkgs) != 22 {
+		t.Fatalf("expected 22 packages, got %d", len(pkgs))
 	}
 	for i, pkg := range pkgs {
 		if pkg.Name == "" {

--- a/internal/tui/splash.go
+++ b/internal/tui/splash.go
@@ -87,6 +87,7 @@ func renderInstallSplash(b *strings.Builder, opts SplashOptions, bullet string) 
 		{"Starship", "cross-shell prompt"},
 		{"fzf", "fuzzy finder"},
 		{"Lazygit", "git TUI"},
+		{"GitHub CLI", "gh command-line client"},
 		{"opencode", "AI coding agent CLI"},
 		{"Lazydocker", "docker TUI"},
 		{"Atuin", "shell history search"},


### PR DESCRIPTION
## Summary
- add `gh` (GitHub CLI) to the Homebrew package manifest so it is installed by Omachy
- update install-facing surfaces (README table and installer splash list) to include GitHub CLI
- audit and sync homepage tiles with installed packages by adding missing tools (`gh`, `opencode`, `lazydocker`, `fastfetch`, `tree-sitter`, `zsh-syntax-highlighting`, `zsh-autosuggestions`) and updating the install count copy to `20+ tools`

Closes #12