### PR TITLE
sketchybar: hide battery item on Macs without a battery

### DIFF
--- a/configs/sketchybar/plugins/battery.sh
+++ b/configs/sketchybar/plugins/battery.sh
@@ -4,7 +4,9 @@ PERCENTAGE=$(pmset -g batt | grep -Eo '[0-9]+%' | tr -d '%')
 CHARGING=$(pmset -g batt | grep 'AC Power')
 
 if [ -z "$PERCENTAGE" ]; then
-    sketchybar --set "$NAME" icon="󱉝" label="?"
+    # No battery (Mac mini, Mac Studio, Mac Pro) — hide the item instead of
+    # showing a permanent "?".
+    sketchybar --set "$NAME" drawing=off
     exit 0
 fi
 
@@ -23,4 +25,4 @@ else
     ICON="󰁺" COLOR=0xfff38ba8   # critical
 fi
 
-sketchybar --set "$NAME" icon="$ICON" icon.color="$COLOR" label="${PERCENTAGE}%"
+sketchybar --set "$NAME" drawing=on icon="$ICON" icon.color="$COLOR" label="${PERCENTAGE}%"


### PR DESCRIPTION
## Problem

On desktop Macs (Mac mini, Mac Studio, Mac Pro), `pmset -g batt` reports no percentage, so the battery plugin falls into its empty-percentage branch and renders a permanent **"󱉝 ?"** item in the bar.

## Fix

Hide the item entirely via `drawing=off` when no percentage is found, and set `drawing=on` in the normal path so the item recovers if a battery is ever detected.

Verified on an M-series Mac mini: before, the bar showed the "󱉝 ?" placeholder; after, the battery item is simply absent while clock/volume/CPU/RAM render normally.

Thanks for omachy — I borrowed several of its ideas (SketchyBar setup, AeroSpace integration, macOS defaults) for my own Omarchy-style macOS config, and this was the one rough edge I hit on a desktop Mac. 🍻

🤖 Generated with [Claude Code](https://claude.com/claude-code)