### PR TITLE
Dynamically adjust AeroSpace top gap for SketchyBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Omachy brings the [Omarchy](https://omakub.org/) experience to macOS — a tilin
 | `tmux/tmux.conf` | `~/.tmux.conf` *(NeverOverwrite)* |
 | `starship.toml` | `~/.config/starship.toml` |
 | `omachy/dev-session.sh` | `~/.config/omachy/dev-session.sh` |
+| `omachy/dynamic-top-gap.sh` | `~/.config/omachy/dynamic-top-gap.sh` |
+| `omachy/com.omachy.dynamic-top-gap.plist` | `~/Library/LaunchAgents/com.omachy.dynamic-top-gap.plist` |
 
 **These files are never overwritten:**
 

--- a/configs/aerospace/aerospace-named.toml
+++ b/configs/aerospace/aerospace-named.toml
@@ -4,6 +4,7 @@ config-version = 2
 after-startup-command = [
     'exec-and-forget sketchybar',
     'exec-and-forget borders active_color="glow(0xff00ffaa)" inactive_color=0xff313244 width=6.0',
+    'exec-and-forget /bin/bash ~/.config/omachy/dynamic-top-gap.sh',
 ]
 
 start-at-login = true
@@ -23,7 +24,7 @@ enable-normalization-flatten-containers = true
 enable-normalization-opposite-orientation-for-nested-containers = true
 
 # ── Mouse follows focus ───────────────────────────────────────────────────────
-on-focused-monitor-changed = []
+on-focused-monitor-changed = ['exec-and-forget /bin/bash ~/.config/omachy/dynamic-top-gap.sh']
 on-focus-changed = []
 
 # ── Sketchybar integration ────────────────────────────────────────────────────

--- a/configs/aerospace/aerospace.toml
+++ b/configs/aerospace/aerospace.toml
@@ -4,6 +4,7 @@ config-version = 2
 after-startup-command = [
     'exec-and-forget sketchybar',
     'exec-and-forget borders active_color="glow(0xff00ffaa)" inactive_color=0xff313244 width=6.0',
+    'exec-and-forget /bin/bash ~/.config/omachy/dynamic-top-gap.sh',
 ]
 
 start-at-login = true
@@ -19,7 +20,7 @@ enable-normalization-flatten-containers = true
 enable-normalization-opposite-orientation-for-nested-containers = true
 
 # ── Mouse follows focus ───────────────────────────────────────────────────────
-on-focused-monitor-changed = []
+on-focused-monitor-changed = ['exec-and-forget /bin/bash ~/.config/omachy/dynamic-top-gap.sh']
 on-focus-changed = []
 
 # ── Sketchybar integration ────────────────────────────────────────────────────

--- a/configs/omachy/com.omachy.dynamic-top-gap.plist
+++ b/configs/omachy/com.omachy.dynamic-top-gap.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.omachy.dynamic-top-gap</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>$HOME/.config/omachy/dynamic-top-gap.sh</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StartInterval</key>
+    <integer>3</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/omachy-dynamic-top-gap.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/omachy-dynamic-top-gap.log</string>
+</dict>
+</plist>

--- a/configs/omachy/dynamic-top-gap.sh
+++ b/configs/omachy/dynamic-top-gap.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -eu
+
+HOME_DIR="${HOME}"
+AEROSPACE_CONFIG="${HOME_DIR}/.config/aerospace/aerospace.toml"
+SKETCHYBAR_CONFIG="${HOME_DIR}/.config/sketchybar/sketchybarrc"
+STATE_DIR="${HOME_DIR}/.omachy"
+MIN_GAP=16
+MAX_GAP=64
+
+if [ ! -f "$AEROSPACE_CONFIG" ] || [ ! -f "$SKETCHYBAR_CONFIG" ]; then
+    exit 0
+fi
+
+if ! command -v swift >/dev/null 2>&1; then
+    exit 0
+fi
+
+if ! command -v aerospace >/dev/null 2>&1; then
+    exit 0
+fi
+
+bar_val() {
+    key="$1"
+    default="$2"
+    value=$(awk -F'=' -v key="$key" '
+        $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2)
+            print $2
+            exit
+        }
+    ' "$SKETCHYBAR_CONFIG")
+    if [ -z "$value" ]; then
+        value="$default"
+    fi
+    echo "$value"
+}
+
+HEIGHT=$(bar_val "height" "36")
+MARGIN=$(bar_val "margin" "8")
+Y_OFFSET=$(bar_val "y_offset" "4")
+
+case "$HEIGHT" in ''|*[!0-9]*) HEIGHT=36 ;; esac
+case "$MARGIN" in ''|*[!0-9]*) MARGIN=8 ;; esac
+case "$Y_OFFSET" in ''|*[!0-9]*) Y_OFFSET=4 ;; esac
+
+FOOTPRINT=$((HEIGHT + MARGIN + Y_OFFSET))
+
+SWIFT_OUT=$(swift -e '
+import AppKit
+
+for s in NSScreen.screens {
+    let frame = s.frame
+    let visible = s.visibleFrame
+    let topInset = Int(round(frame.maxY - visible.maxY))
+    let name = (s.localizedName as NSString).lowercased
+    print("\(name)|\(topInset)")
+}
+' 2>/dev/null || true)
+
+if [ -z "$SWIFT_OUT" ]; then
+    exit 0
+fi
+
+built_in_inset=""
+external_max_gap=0
+
+while IFS='|' read -r name top_inset; do
+    [ -z "$name" ] && continue
+    case "$top_inset" in ''|*[!0-9]*) continue ;; esac
+
+    gap=$((FOOTPRINT - top_inset))
+    if [ "$gap" -lt "$MIN_GAP" ]; then
+        gap=$MIN_GAP
+    fi
+    if [ "$gap" -gt "$MAX_GAP" ]; then
+        gap=$MAX_GAP
+    fi
+
+    case "$name" in
+        *built-in*)
+            built_in_inset="$gap"
+            ;;
+        *)
+            if [ "$gap" -gt "$external_max_gap" ]; then
+                external_max_gap="$gap"
+            fi
+            ;;
+    esac
+done <<EOF
+$SWIFT_OUT
+EOF
+
+if [ -z "$built_in_inset" ]; then
+    built_in_inset=$MIN_GAP
+fi
+
+if [ "$external_max_gap" -eq 0 ]; then
+    external_max_gap=$((FOOTPRINT))
+    if [ "$external_max_gap" -lt "$MIN_GAP" ]; then
+        external_max_gap=$MIN_GAP
+    fi
+    if [ "$external_max_gap" -gt "$MAX_GAP" ]; then
+        external_max_gap=$MAX_GAP
+    fi
+fi
+
+NEW_OUTER_TOP="    outer.top        = [{monitor.'built-in' = ${built_in_inset}}, ${external_max_gap}]"
+
+CURRENT_OUTER_TOP=$(awk '/^[[:space:]]*outer\.top[[:space:]]*=/{print; exit}' "$AEROSPACE_CONFIG" || true)
+
+if [ "$CURRENT_OUTER_TOP" = "$NEW_OUTER_TOP" ]; then
+    exit 0
+fi
+
+tmp_file="${AEROSPACE_CONFIG}.tmp"
+awk -v replacement="$NEW_OUTER_TOP" '
+    /^[[:space:]]*outer\.top[[:space:]]*=/ {
+        print replacement
+        next
+    }
+    { print }
+' "$AEROSPACE_CONFIG" > "$tmp_file"
+mv "$tmp_file" "$AEROSPACE_CONFIG"
+
+aerospace reload-config >/dev/null 2>&1 || true

--- a/internal/installer/defaults.go
+++ b/internal/installer/defaults.go
@@ -2,6 +2,8 @@ package installer
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -82,6 +84,10 @@ func runSystem(p *tea.Program, opts Options) error {
 		shell.Run("killall", "Dock")
 		log("==> Restarting SystemUIServer (menu bar)")
 		shell.Run("killall", "SystemUIServer")
+
+		if err := loadDynamicTopGapAgent(log); err != nil {
+			log(fmt.Sprintf("    Warning: failed to load dynamic top gap agent: %v", err))
+		}
 	}
 
 	p.Send(tui.ProgressUpdate{Percent: 90})
@@ -191,4 +197,34 @@ func appendUnique(slice []string, item string) []string {
 		}
 	}
 	return append(slice, item)
+}
+
+func loadDynamicTopGapAgent(log func(string)) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.omachy.dynamic-top-gap.plist")
+	if _, err := os.Stat(plistPath); err != nil {
+		if os.IsNotExist(err) {
+			log("    Dynamic top gap agent plist not found, skipping")
+			return nil
+		}
+		return err
+	}
+
+	log("==> Loading dynamic top gap monitor agent")
+	if _, err := shell.Run("launchctl", "bootout", "gui/"+fmt.Sprintf("%d", os.Getuid()), plistPath); err != nil {
+		// best effort: ignore if not loaded yet
+	}
+	if _, err := shell.Run("launchctl", "bootstrap", "gui/"+fmt.Sprintf("%d", os.Getuid()), plistPath); err != nil {
+		return err
+	}
+	if _, err := shell.Run("launchctl", "enable", "gui/"+fmt.Sprintf("%d", os.Getuid())+"/com.omachy.dynamic-top-gap"); err != nil {
+		return err
+	}
+	if _, err := shell.Run("launchctl", "kickstart", "-k", "gui/"+fmt.Sprintf("%d", os.Getuid())+"/com.omachy.dynamic-top-gap"); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -80,5 +80,7 @@ func Configs() []ConfigMapping {
 		{Source: "tmux/tmux.conf", Dest: "~/.tmux.conf", Mode: 0644, NeverOverwrite: true},
 		{Source: "starship.toml", Dest: "~/.config/starship.toml", Mode: 0644},
 		{Source: "omachy/dev-session.sh", Dest: "~/.config/omachy/dev-session.sh", Mode: 0755},
+		{Source: "omachy/dynamic-top-gap.sh", Dest: "~/.config/omachy/dynamic-top-gap.sh", Mode: 0755},
+		{Source: "omachy/com.omachy.dynamic-top-gap.plist", Dest: "~/Library/LaunchAgents/com.omachy.dynamic-top-gap.plist", Mode: 0644},
 	}
 }

--- a/internal/uninstaller/uninstaller.go
+++ b/internal/uninstaller/uninstaller.go
@@ -112,6 +112,10 @@ func stopServices(p *tea.Program, opts Options) error {
 		}
 	}
 
+	if err := unloadDynamicTopGapAgent(log, opts.DryRun); err != nil {
+		log(fmt.Sprintf("    Warning: failed to unload dynamic top gap agent: %v", err))
+	}
+
 	return nil
 }
 
@@ -340,4 +344,36 @@ func shortPath(path string) string {
 		return "~" + path[len(home):]
 	}
 	return path
+}
+
+func unloadDynamicTopGapAgent(log func(string), dryRun bool) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.omachy.dynamic-top-gap.plist")
+	if _, err := os.Stat(plistPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	uid := fmt.Sprintf("%d", os.Getuid())
+	service := "gui/" + uid + "/com.omachy.dynamic-top-gap"
+	if dryRun {
+		log("==> Would unload dynamic top gap monitor agent")
+		return nil
+	}
+
+	log("==> Unloading dynamic top gap monitor agent")
+	if _, err := shell.Run("launchctl", "disable", service); err != nil {
+		// best effort
+	}
+	if _, err := shell.Run("launchctl", "bootout", "gui/"+uid, plistPath); err != nil {
+		if !strings.Contains(err.Error(), "No such process") {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- add a dynamic top-gap helper script that computes AeroSpace `outer.top` from SketchyBar geometry and per-display top insets
- run the helper on AeroSpace startup and focused-monitor changes
- add a LaunchAgent poller (3s) to handle monitor hotplug/unplug edge cases and apply changes automatically
- deploy/unload LaunchAgent through installer/uninstaller and include new managed files in docs

## Details
- clamp computed gaps to `16..64`
- update only when `outer.top` changes to avoid unnecessary reload churn
- keep built-in monitor mapping explicit and external displays as fallback default

Closes #17