### PR TITLE
borders: make bordersrc the single source of truth

### DIFF
--- a/configs/aerospace/aerospace-named.toml
+++ b/configs/aerospace/aerospace-named.toml
@@ -3,7 +3,7 @@ config-version = 2
 # ── Startup ──────────────────────────────────────────────────────────────────
 after-startup-command = [
     'exec-and-forget sketchybar',
-    'exec-and-forget borders active_color="glow(0xff00ffaa)" inactive_color=0xff313244 width=6.0',
+    'exec-and-forget borders',
     'exec-and-forget /bin/bash ~/.config/omachy/dynamic-top-gap.sh',
 ]
 

--- a/configs/aerospace/aerospace.toml
+++ b/configs/aerospace/aerospace.toml
@@ -3,7 +3,7 @@ config-version = 2
 # ── Startup ──────────────────────────────────────────────────────────────────
 after-startup-command = [
     'exec-and-forget sketchybar',
-    'exec-and-forget borders active_color="glow(0xff00ffaa)" inactive_color=0xff313244 width=6.0',
+    'exec-and-forget borders',
     'exec-and-forget /bin/bash ~/.config/omachy/dynamic-top-gap.sh',
 ]
 

--- a/configs/borders/bordersrc
+++ b/configs/borders/bordersrc
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-borders active_color=0xff7C3AED \
-        inactive_color=0x4D4D4D4D \
-        width=2.0 \
+borders active_color="glow(0xff00ffaa)" \
+        inactive_color=0xff313244 \
+        width=6.0 \
         style=round


### PR DESCRIPTION
## Summary
- AeroSpace launched JankyBorders with inline arguments (`exec-and-forget borders active_color=... width=6.0`), so the deployed `~/.config/borders/bordersrc` was never sourced — JankyBorders only reads that file when launched **without** args. The deployed file was dead config and disagreed with the inline values.
- Launch plain `exec-and-forget borders` in both `aerospace.toml` and `aerospace-named.toml`, making `bordersrc` the single source of truth. Borders can now be themed by editing one file, consistent with how every other tool in omachy is configured.
- Move the current effective appearance (`glow(0xff00ffaa)` / `0xff313244` / width 6.0 / round) into `bordersrc` so there is **no visual change** — only the mechanism changes.

## Testing
- `go build`, `go vet ./...`, `gofmt`, `go test ./...` — all clean.
- Ran the new `bordersrc` against the live JankyBorders daemon: exit 0, glow values apply correctly (confirms `glow(...)` syntax works via the file, not just inline).
- Installed on a real machine and restarted AeroSpace: it relaunched `borders` with **no args** (verified via `pgrep`), i.e. the source-from-file path now works end-to-end.

## Notes
- Surfaced a separate, pre-existing bug while testing: borders daemons accumulate because each launch is fire-and-forget with no dedupe. Filed as #25 — out of scope for this PR.

Closes #21