### PR TITLE
docs: add Ko-fi donation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/user-attachments/assets/ba95b0f2-8d99-4987-b2f5-fa932f45a259
 
 Omachy brings the [Omarchy](https://omakub.org/) experience to macOS — a tiling WM, custom menu bar, terminal emulator, editor, and sane system defaults, all configured in one shot. For people who'd rather be on Linux but can't.
 
-**[Homepage](https://omachy.org)** · **[Usage Guide](https://omachy.org/guide.html)**
+**[Homepage](https://omachy.org)** · **[Usage Guide](https://omachy.org/guide.html)** · **[🍺 Buy me a beer](https://ko-fi.com/dough654)**
 
 ## What Gets Installed
 
@@ -244,6 +244,12 @@ Tests cover the pure logic and I/O packages: manifest data, checksum computation
 ### CI coverage
 
 - `ci.yml` runs on pull requests and pushes to `master`: `gofmt` check, `go vet ./...`, and `go test ./...`.
+
+## Support
+
+If Omachy saved you some setup time, you can buy me a beer — no pressure, always appreciated.
+
+[![Buy me a beer](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/dough654)
 
 ## License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -454,7 +454,7 @@
     </section>
 
     <footer>
-      <a href="guide.html">Guide</a> &middot; <a href="https://github.com/dough654/Omachy">GitHub</a> &middot; MIT License &middot; Inspired by <a href="https://omakub.org/">Omarchy</a>
+      <a href="guide.html">Guide</a> &middot; <a href="https://github.com/dough654/Omachy">GitHub</a> &middot; MIT License &middot; Inspired by <a href="https://omakub.org/">Omarchy</a> &middot; <a href="https://ko-fi.com/dough654" target="_blank" rel="noopener">Buy me a beer &#127866;</a>
     </footer>
   </div>
   <div class="video-overlay" id="video-overlay">


### PR DESCRIPTION
## Summary
Adds "buy me a beer" Ko-fi links so people can support the project, as requested in #22.

- **Site footer** (`docs/index.html`) — a styled text link alongside the existing `Guide · GitHub · MIT License · Omarchy` links. Deliberately a plain `<a>` rather than Ko-fi's prebaked widget/button, to avoid adding an external script or tracker to a page that currently has none.
- **README** — a link in the top `Homepage · Usage Guide` line, plus a new `## Support` section with the standard Ko-fi badge before the License section.

Links point to https://ko-fi.com/dough654.

## Verification
- Ko-fi badge image (`githubbutton_sm.svg`) returns 200.
- Profile link confirmed loading in-browser by the owner.

Closes #22